### PR TITLE
Removed second argument from a Command::option() call

### DIFF
--- a/config/server.php
+++ b/config/server.php
@@ -63,7 +63,7 @@ return [
     |
     */
 
-    'max_connections' => env('SERVER_MAX_CONNECTIONS'),
+    'max_connections' => env('SERVER_MAX_CONNECTIONS', '0'),
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Console/ServerStart.php
+++ b/src/Console/ServerStart.php
@@ -60,7 +60,7 @@ class ServerStart extends Command
             ->uses($this->getOutput())
             ->uses(Queue::connection($this->option('connector')), $this->option('queue'))
             ->password($this->option('key'))
-            ->maxConnections($this->option('max', 0))
+            ->maxConnections($this->option('max'))
             ->start();
     }
 }


### PR DESCRIPTION
That function only takes one argument. Second argument just adds confusion.